### PR TITLE
Added interfaces for data sets and tweaked schema

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -24,4 +24,4 @@ app.use('/api/users', userRoutes_1.default);
 app.use((req, res, next) => {
     res.status(404).end();
 });
-app.listen(3000);
+app.listen(3001);

--- a/build/controllers/userController.js
+++ b/build/controllers/userController.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.loginUser = exports.createUser = void 0;
+exports.getUser = exports.loginUser = exports.createUser = void 0;
 const user_1 = require("../models/user");
 const auth_1 = require("../services/auth");
 const createUser = async (req, res, next) => {
@@ -44,3 +44,17 @@ const loginUser = async (req, res, next) => {
     }
 };
 exports.loginUser = loginUser;
+const getUser = async (req, res, next) => {
+    let user = await (0, auth_1.verifyUser)(req, res, next);
+    if (user) {
+        let { _id, username } = user;
+        res.status(200).json({
+            _id,
+            username
+        });
+    }
+    else {
+        res.status(401).send();
+    }
+};
+exports.getUser = getUser;

--- a/build/routes/userRoutes.js
+++ b/build/routes/userRoutes.js
@@ -5,4 +5,5 @@ const userController_1 = require("../controllers/userController");
 const router = (0, express_1.Router)();
 router.post('/', userController_1.createUser);
 router.post('/login', userController_1.loginUser);
+router.get('/:id', userController_1.getUser);
 exports.default = router;

--- a/src/models/resume.ts
+++ b/src/models/resume.ts
@@ -1,66 +1,164 @@
 import { Document, Schema, Model, model } from 'mongoose';
 import { IUser } from './user';
 
+interface Identity {
+    firstName: string;
+    lastName: string;
+    title: string;
+    address: string;
+    phone: string;
+    email: string;
+    linkedIn?: string;
+}
+
+interface Skills {
+    skills?: string[];
+}
+
+interface Jobs {
+    title?: string;
+    company?: string;
+    start?: string;
+    end?: string;
+    accomplishments?: string;
+}
+
+interface Projects {
+    title?: string;
+    start?: string;
+    end?: string;
+    accomplishments?: string;
+}
+
+interface Education {
+    school?: string;
+    degree?: string;
+    dateAcquired?: string;
+}
+
+interface Certifications {
+    certification?: string;
+    provider?: string;
+    dateAcquired?: string;
+}
+
 interface IResume extends Document {
-   firstName: string;
-   lastName: string;
-   title: string;
-   address: string;
-   phone: string; 
-   email: string;
-   skills : string;
-   job: string;
-   project: string; 
-   education: string;
-   certification: string;
+   identity: Identity;
+   skills : Skills[];
+   jobs: Jobs[];
+   project: Projects[];
+   education: Education[];
+   certification: Certifications[];
    userId: IUser['_id'];
 }
 
 const resumeSchema: Schema = new Schema({
-    firstName: {
-        type: String,
-        required: true
-    }, 
-    lastName: {
-        type: String,
-        required: true
+    identity: {
+        firstName: {
+            type: String,
+            required: true
+        }, 
+        lastName: {
+            type: String,
+            required: true
+        },
+        title: {
+            type: String,
+            required: true
+        },
+        address: {
+            type: String,
+            required: true
+        },
+        phone: {
+            type: String,
+            required: true
+        },
+        email: {
+            type: String,
+            required: true
+        },
+        linkedIn: {
+            type: String,
+            required: false
+        }
     },
-    title: {
+    skills: [{
         type: String,
-        required: true
-    },
-    address: {
-        type: String,
-        required: true
-    },
-    phone: {
-        type: String,
-        required: true
-    },
-    email: {
-        type: String,
-        required: true
-    },
-    skills: {
-        type: String,
-        required: true
-    },
-    job: {
-        type: String,
-        required: true
-    },
-    project: {
-        type: String,
-        required: true
-    },
-    education: {
-        type: String,
-        required: true
-    }, 
-    certification: {
-        type: String,
-        required: true
-    },
+        required: false
+    }],
+    jobs: [{
+        title: {
+            type: String,
+            required: false
+        }, 
+        company: {
+            type: String,
+            required: false
+        },
+        start: {
+            type: String,
+            required: false
+        },
+        end: {
+            type: String,
+            required: false
+        },
+        accomplishments: {
+            type: String,
+            required: false
+        }
+    }],
+    project: [{
+        title: {
+            type: String,
+            required: false
+        }, 
+        company: {
+            type: String,
+            required: false
+        },
+        start: {
+            type: String,
+            required: false
+        },
+        end: {
+            type: String,
+            required: false
+        },
+        accomplishments: {
+            type: String,
+            required: false
+        }
+    }],
+    education: [{
+        school: {
+            type: String,
+            required: false
+        }, 
+        degree: {
+            type: String,
+            required: false
+        },
+        dateAcquired: {
+            type: String,
+            required: false
+        }
+    }], 
+    certification: [{
+        certification: {
+            type: String,
+            required: false
+        }, 
+        provider: {
+            type: String,
+            required: false
+        },
+        dateAcquired: {
+            type: String,
+            required: false
+        }
+    }],
     userId: {
         type: Schema.Types.ObjectId,
         ref: 'User',


### PR DESCRIPTION
I added separate interfaces for each data group in the builder form, with 'identity' being the only one required, with subset 'linkedIn' being optional.  All other interfaces are designated as arrays since a user could potentially have multiple of each.  Let me know if this looks okay to you guys, I am working on a hotspot at work so did not have time or ability to test this out with frontend yet.  Hoping this will work to save resumes to the database